### PR TITLE
feat: Render images from s3 without auth header

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,5 @@
 {
     "extends": [
-        "eslint-config-blueflag",
-        "eslint-config-blueflag/flow.js"
+        "eslint-config-blueflag"
     ]
 }

--- a/src/processes/extract-origin.ts
+++ b/src/processes/extract-origin.ts
@@ -1,0 +1,6 @@
+
+function extractOrigin(url: string): string {
+    return url.replace(/^((\w+:)?\/\/[^\/]+).*$/, '$1');
+}
+
+export default extractOrigin;

--- a/src/processes/render-pdf.ts
+++ b/src/processes/render-pdf.ts
@@ -3,64 +3,98 @@ import chromium from 'chrome-aws-lambda';
 import {RenderParams, Orientation} from '../types';
 import shortid from 'shortid';
 import path from 'path';
+import extractOrigin from './extract-origin';
 
 const format = 'pdf';
 
 export default async function renderPdf(params: RenderParams): Promise<string> {
-	const {path: uri} = params;
+    const {path: uri} = params;
     const jwt: string|undefined = params.jwt;
-	const destDir = params.destDir || './';
-	const filename: string = path.join(destDir, `${shortid.generate()}.${format}`);
+    const destDir = params.destDir || './';
+    const filename: string = path.join(destDir, `${shortid.generate()}.${format}`);
 
-	if(!path) {
-		throw new Error('No render path provided');
-	}
+    if(!path) {
+        throw new Error('No render path provided');
+    }
 
-	console.log(puppeteer);
+    console.log(puppeteer);
 
-	console.log(`Render ${uri}`);
+    console.log(`Render ${uri}`);
 
-	try {
-		const executablePath = await chromium.executablePath;
-		console.log('path', {executablePath});
-	console.log('launching...');
-		const browser: Browser = await puppeteer.launch({
-				args: chromium.args,
-				defaultViewport: chromium.defaultViewport,
-				executablePath,
-				headless: chromium.headless,
-				ignoreHTTPSErrors: true
-		});
-		console.log('browser', browser);
-		const page: Page = await browser.newPage();
+    try {
+        const executablePath = await chromium.executablePath;
+        console.log('path', {executablePath});
+        console.log('launching...');
+        const browser: Browser = await puppeteer.launch({
+                args: chromium.args,
+                defaultViewport: chromium.defaultViewport,
+                executablePath,
+                headless: chromium.headless,
+                ignoreHTTPSErrors: true
+        });
+        console.log('browser', browser);
+        const page: Page = await browser.newPage();
         if(jwt) {
           await page.setExtraHTTPHeaders({'Authorization': `Bearer ${jwt}`});
-          console.log(`Set bearer token ${jwt}`);
+          console.log(`Set bearer token`);
         }
         if(params.cookie) {
-          await page.setExtraHTTPHeaders({'cookie': params.cookie}});
+          await page.setExtraHTTPHeaders({'cookie': params.cookie});
           console.log('Set cookie');
         }
-		console.log('page');
-		await page.goto(uri);
-		console.log('navigate');
-		//await page.screenshot({path: 'test.png'});
-		await page.pdf({
-			path: filename,
-			printBackground: true,
-			format: params.paperSize,
-			landscape: params.orientation == Orientation.landscape
 
-		});
-		console.log('pdf');
 
-		await browser.close();
-		console.log('close');
+        // If the request is an image from another origin or any resouce from s3 exclude the auth header
+        await page.setRequestInterception(true);
+        const baseOrigin = extractOrigin(uri);
+        page.on('request', (request) => {
+          const reqOrigin = extractOrigin(request.url());
+          if(
+            (request.resourceType() == 'image' && baseOrigin !== reqOrigin)
+            || reqOrigin.indexOf('amazonaws.com') > 0
+          ) {
+            // Override headers
+            const headers = Object.assign({}, request.headers(), {
+              authorization: undefined, // remove auth header
+            });
+            request.continue({ headers });
+          } else {
+            request.continue();
+          }
+        });
 
-	} catch (err: any) {
-		console.error(err);
-	}
+        console.log('page');
+        await page.goto(uri);
+        console.log('navigate');
+    await page.waitForSelector('#PDF_LOADING', {hidden: true});
 
-	return filename;
+    await page.$$eval('img[src]', imgs => Promise.all(imgs.map(img => {
+      if(img.complete) {
+        return;
+      }
+      return new Promise((resolve, reject) => {
+        img.addEventListener(resolve);
+        img.addEventListener(reject);
+      });
+    })));
+    console.log('images loaded');
+        //await page.screenshot({path: 'test.png'});
+        await page.pdf({
+            path: filename,
+            printBackground: true,
+            format: params.paperSize,
+            landscape: params.orientation == Orientation.landscape
+
+        });
+        console.log('pdf');
+
+        await browser.close();
+        console.log('close');
+
+    } catch (err: any) {
+        console.error(err);
+    }
+
+    return filename;
 }
 

--- a/src/processes/render-pdf.ts
+++ b/src/processes/render-pdf.ts
@@ -73,8 +73,8 @@ export default async function renderPdf(params: RenderParams): Promise<string> {
         return;
       }
       return new Promise((resolve, reject) => {
-        img.addEventListener(resolve);
-        img.addEventListener(reject);
+        img.addEventListener('load', resolve);
+        img.addEventListener('error', reject);
       });
     })));
     console.log('images loaded');

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,32 +5,32 @@ interface Dictionary<T> {
 };
 
 const PaperSize = {
-    a3: 'a3',
-		a4: 'a4',
-		a5: 'a5',
-		legal: 'legal',
-		letter: 'letter',
-		tabloid: 'tabloid'
+  a3: 'a3',
+  a4: 'a4',
+  a5: 'a5',
+  legal: 'legal',
+  letter: 'letter',
+  tabloid: 'tabloid'
 } as const;
 
 enum Orientation {
-		portrait = 'portrait',
-		landscape = 'landscape'
+  portrait = 'portrait',
+  landscape = 'landscape'
 };
 
 interface RenderParams {
-    jwt?: string,
-    cookie?: string,
-    cookies?: Dictionary<string>,
-    path: string,
-    paperSize: "letter" | "legal" | "tabloid" | "ledger" | "a0" | "a1" | "a2" | "a3" | "a4" | "a5" | "a6" | undefined,
-    orientation: Orientation,
-		destDir?: string
+  jwt?: string,
+  cookie?: string,
+  cookies?: Dictionary<string>,
+  path: string,
+  paperSize: "letter" | "legal" | "tabloid" | "ledger" | "a0" | "a1" | "a2" | "a3" | "a4" | "a5" | "a6" | undefined,
+  orientation: Orientation,
+  destDir?: string
 };
 
 export {
-	Dictionary,
-	PaperSize,
-	Orientation,
-	RenderParams
+  Dictionary,
+  PaperSize,
+  Orientation,
+  RenderParams
 };


### PR DESCRIPTION
- Strip authorization headers from image requests to a different domain or any requests to s3
- Wait for all images to load before rendering PDF